### PR TITLE
Fix server port parsing

### DIFF
--- a/CreateServerWindow.xaml.cs
+++ b/CreateServerWindow.xaml.cs
@@ -16,7 +16,11 @@ namespace DiceRoller
         private void StartServer_Click(object sender, RoutedEventArgs e)
         {
             string ip = IpAddressTextBox.Text;
-            int port = int.Parse(PortTextBox.Text);
+            if (!int.TryParse(PortTextBox.Text, out int port))
+            {
+                MessageBox.Show("Invalid port number.", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                return;
+            }
             ((App)Application.Current).MainWindow = new MainWindow();
             ((MainWindow)((App)Application.Current).MainWindow).StartServer(ip, port);
             Close();

--- a/JoinServerWindow.xaml.cs
+++ b/JoinServerWindow.xaml.cs
@@ -16,7 +16,11 @@ namespace DiceRoller
         private void JoinServer_Click(object sender, RoutedEventArgs e)
         {
             string ip = IpAddressTextBox.Text;
-            int port = int.Parse(PortTextBox.Text);
+            if (!int.TryParse(PortTextBox.Text, out int port))
+            {
+                MessageBox.Show("Invalid port number.", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                return;
+            }
             string username = UsernameTextBox.Text;
             ((App)Application.Current).MainWindow = new MainWindow();
             ((MainWindow)((App)Application.Current).MainWindow).ConnectToServer(ip, port, username);


### PR DESCRIPTION
## Summary
- validate port input using `int.TryParse`
- warn about invalid port before starting or joining

## Testing
- `dotnet build DiceRoller.csproj` *(fails: command not found)*
- `msbuild DiceRoller.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842c75fda748333a80c338468ec0ddc