### PR TITLE
Use shared Random instance

### DIFF
--- a/DiceRollSetupWindow.xaml.cs
+++ b/DiceRollSetupWindow.xaml.cs
@@ -29,6 +29,7 @@ namespace DiceRoller
         private int characterAttribute;
         private MainWindow mainWindow;
         private Server server;
+        private static readonly Random random = new Random();
 
         public DiceRollSetupWindow(int skillLevel, int characterAttribute, MainWindow main, Server server)
         {
@@ -57,7 +58,6 @@ namespace DiceRoller
 
         public void RollAndDisplayDice(int totalDice, Difficulty difficulty)
         {
-            Random random = new Random();
             StringBuilder resultBuilder = new StringBuilder();
             int successThreshold = SuccessThresholds.GetThreshold(skillLevel, difficulty);
             int successCount = 0;


### PR DESCRIPTION
## Summary
- share a single `Random` object in `DiceRollSetupWindow`
- remove per-call instantiation in `RollAndDisplayDice`

## Testing
- `dotnet build DiceRoller.csproj` *(fails: dotnet not found)*
- `msbuild DiceRoller.csproj` *(fails: msbuild not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842c761376c8333a6665806685f6bd5