### PR TITLE
Clean unused using directives

### DIFF
--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Configuration;
-using System.Data;
-using System.Linq;
-using System.Threading.Tasks;
-using System.Windows;
+﻿using System.Windows;
 
 namespace DiceRoller
 {

--- a/CharacterSheet.xaml.cs
+++ b/CharacterSheet.xaml.cs
@@ -1,23 +1,13 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Data;
 using System.Windows.Documents;
-using System.Windows.Input;
 using System.Windows.Media;
 using System.IO;
-using System.Windows.Controls;
-
-using System.Windows.Media.Imaging;
-using System.Windows.Shapes;
 using Newtonsoft.Json;
-using System.Xml;
 using Formatting = Newtonsoft.Json.Formatting;
-using System.Windows.Markup;
 namespace DiceRoller
 {
     /// <summary>

--- a/DiceRollSetupWindow.xaml.cs
+++ b/DiceRollSetupWindow.xaml.cs
@@ -1,17 +1,7 @@
-﻿using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System;
 using System.Text;
-using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Shapes;
 
 namespace DiceRoller
 {

--- a/HomeWindow.xaml.cs
+++ b/HomeWindow.xaml.cs
@@ -1,16 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Shapes;
 
 namespace DiceRoller
 {

--- a/Server.cs
+++ b/Server.cs
@@ -6,7 +6,6 @@ using System.Net.Sockets;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using Newtonsoft.Json;
 
 namespace DiceRoller
 {


### PR DESCRIPTION
## Summary
- drop unnecessary `using` statements across source files

## Testing
- `xbuild /t:Build DiceRoller.csproj` *(fails: TargetFrameworkVersion 'v4.8' not supported)*

------
https://chatgpt.com/codex/tasks/task_e_6842c762e198833391162caafff0fe89