### PR TITLE
Disable signing settings

### DIFF
--- a/DiceRoller.csproj
+++ b/DiceRoller.csproj
@@ -50,19 +50,19 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup>
-    <SignManifests>true</SignManifests>
+    <!-- <SignManifests>true</SignManifests> -->
   </PropertyGroup>
   <PropertyGroup>
     <ApplicationIcon>DALL·E-2024-05-06-16.45.ico</ApplicationIcon>
   </PropertyGroup>
   <PropertyGroup>
-    <SignAssembly>true</SignAssembly>
+    <!-- <SignAssembly>true</SignAssembly> -->
   </PropertyGroup>
   <PropertyGroup>
-    <ManifestCertificateThumbprint>8F03C4B3969E84D516A567A17C602D7A932928A2</ManifestCertificateThumbprint>
+    <!-- <ManifestCertificateThumbprint>8F03C4B3969E84D516A567A17C602D7A932928A2</ManifestCertificateThumbprint> -->
   </PropertyGroup>
   <PropertyGroup>
-    <ManifestKeyFile>DiceRoller_4_TemporaryKey.pfx</ManifestKeyFile>
+    <!-- <ManifestKeyFile>DiceRoller_4_TemporaryKey.pfx</ManifestKeyFile> -->
   </PropertyGroup>
   <PropertyGroup>
     <AssemblyOriginatorKeyFile>


### PR DESCRIPTION
## Summary
- comment out code signing configuration in `DiceRoller.csproj`

## Testing
- `dotnet msbuild DiceRoller.csproj -t:Restore,Build -p:Configuration=Release` *(fails: reference assemblies for .NETFramework,Version=v4.8 not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842cb53d31083339d00356ad57778d6